### PR TITLE
Add notes on how documentation, decisions are made

### DIFF
--- a/docs/docs.adoc
+++ b/docs/docs.adoc
@@ -1,0 +1,39 @@
+= Docs
+
+Documentation is perhaps the most important part of the moar.fit project.
+
+It is the canonical way of proposing any changes to:
+
+- Software design
+- Business design
+- Personnel decisions
+- Anything else
+
+Changes are made via:
+
+1. Locating the appropriate documentation
+2. Modifying the documentation
+3. Modifying that documentation on a separate `git` branch
+4. Creating a pull request against the `master` branch
+
+== Where to find documentation
+
+Documentation for this service is in several places, designed to make it as easy as possible to maintain and discover.
+
+.Table Where to find information
+|===
+| Type | Source | Display
+
+| Business Information
+| Within this repository in `${GIT_ROOT}/docs/business`
+| Within the GitHub reviewer
+
+| API Documentation
+| https://github.com/moarfit/dev.moar.fit[The dev.moar.fit repository]
+| https://dev.moar.fit/[dev.moar.fit]
+|===
+
+== Format
+
+Documentation is generally written in AsciiDoc format. To read the documentation open the file with an appropriate
+reader,or render the documentation with the https://asciidoctor.org/[AsciiDoc] or compatible tooling.


### PR DESCRIPTION
Within any given structure or organisational process, decisions need to
be made collaboratively, approved and integrated into standard process.

This somewhat informal process mirrors the much stricter process of
managing logic changes within software. Accordingly, it stands to reason
that business decisions can be expressed in terms of the same version
control as software, if the "software" that is being modified is
documentation.

This commit adds documentation that, in turn, proposes itself.

== Design Notes ==

=== Asciidoc ===

The documentation is required to be written in the otherwise bespoke
format of "AsciiDoc". This format has several significant downsides:

- It's not in widespread use
- Support is limited
- It's a bit weird

However, the author is currently experimenting with the format and is
currently finding the positives of the language offset the negatives:

- It allows expressing documentation in a number of ways, such as a
  website, book etc.
- It is not dissimilar to the Markdown syntax more commonly used
- It is extensible and the more fuller featured language is useful in
  conveying longform ideas.
- Its in the same format that O'Reilly uses, and the author at some
  point wants to write a book. So, it's good practice.

Accordingly, this format is chosen.